### PR TITLE
fix tempo reset (could trigger a division by zero)

### DIFF
--- a/TapTempo.pl
+++ b/TapTempo.pl
@@ -91,6 +91,8 @@ while (defined(my $key = <STDIN>))
     if (($times[($#times)] - $times[($#times-1)]) > $reset)
     {
         shift @times while (scalar(@times) > 1);
+        say "Tempo Reset";
+        next;
     }
 
     # Ne conserver que les $sample derniers échantillons


### PR DESCRIPTION
The tempo reset triggers a division by zero: it leaves @times with only
one element, and $timesMean is 0 in such a case.